### PR TITLE
future proofing multiqc numeric protein name bug (proper strings will be shown in html after next MultiQC update)

### DIFF
--- a/bin/extract_family_reps.py
+++ b/bin/extract_family_reps.py
@@ -48,7 +48,7 @@ def extract_first_sequences(msa_folder, metadata_file, out_fasta):
             "# format: \"csv\"\n"
             "# plot_type: \"table\"\n"
         )
-        csv_writer = csv.writer(csv_out)
+        csv_writer = csv.writer(csv_out, quoting=csv.QUOTE_NONNUMERIC)
         # Write the CSV header
         csv_writer.writerow(["Sample Name", "Family Id", "Size", "Representative Length", "Representative Id", "Sequence"])
 


### PR DESCRIPTION
… work with next multiqc version update)

<!--
# nf-core/proteinfamilies pull request

Many thanks for contributing to nf-core/proteinfamilies!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/proteinfamilies/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/proteinfamilies/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/proteinfamilies _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
